### PR TITLE
feat: update session cards with D3 charts, animations, and improvements (EYE-34, EYE-35, EYE-37)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,8 @@
         "@mediapipe/tasks-vision": "0.10.21",
         "@radix-ui/react-icons": "^1.3.2",
         "@radix-ui/themes": "^3.2.1",
+        "@types/d3": "^7.4.3",
+        "d3": "^7.9.0",
         "lucide-react": "^0.525.0",
         "next": "15.4.2",
         "react": "19.1.0",
@@ -3999,10 +4001,72 @@
         "@types/deep-eql": "*"
       }
     },
+    "node_modules/@types/d3": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
+      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
     "node_modules/@types/d3-array": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.1.tgz",
       "integrity": "sha512-Y2Jn2idRrLzUfAKV2LyRImR+y4oa2AntrgID95SHJxuMUrkNXmanDSed71sRNZysveJVt1hLLemQZIady0FpEg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-chord": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
       "license": "MIT"
     },
     "node_modules/@types/d3-color": {
@@ -4011,10 +4075,83 @@
       "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
       "license": "MIT"
     },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.6.tgz",
+      "integrity": "sha512-4fvZhzMeeuBJYZXRXrRIQnvUYfyXwYmLsdiN7XXmVNQKKw1cM8a5WdID0g1hVFZDqT9ZqZEY5pD44p24VS7iZQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+      "license": "MIT"
+    },
     "node_modules/@types/d3-ease": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
       "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
       "license": "MIT"
     },
     "node_modules/@types/d3-interpolate": {
@@ -4032,6 +4169,24 @@
       "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
       "license": "MIT"
     },
+    "node_modules/@types/d3-polygon": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-random": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.3.tgz",
+      "integrity": "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/d3-scale": {
       "version": "4.0.9",
       "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
@@ -4040,6 +4195,18 @@
       "dependencies": {
         "@types/d3-time": "*"
       }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
     },
     "node_modules/@types/d3-shape": {
       "version": "3.1.7",
@@ -4056,11 +4223,36 @@
       "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
       "license": "MIT"
     },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+      "license": "MIT"
+    },
     "node_modules/@types/d3-timer": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
       "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
     },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
@@ -4091,6 +4283,12 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
@@ -5429,6 +5627,15 @@
         "simple-swizzle": "^0.2.2"
       }
     },
+    "node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -5486,6 +5693,47 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-array": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
@@ -5493,6 +5741,43 @@
       "license": "ISC",
       "dependencies": {
         "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "1 - 3"
       },
       "engines": {
         "node": ">=12"
@@ -5507,6 +5792,77 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-ease": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
@@ -5516,10 +5872,57 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-format": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
       "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
       "license": "ISC",
       "engines": {
         "node": ">=12"
@@ -5546,6 +5949,33 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-scale": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
@@ -5558,6 +5988,28 @@
         "d3-time": "2.1.1 - 3",
         "d3-time-format": "2 - 4"
       },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
       "engines": {
         "node": ">=12"
       }
@@ -5603,6 +6055,41 @@
       "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
       "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
       "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
       "engines": {
         "node": ">=12"
       }
@@ -5764,6 +6251,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delaunator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.1.tgz",
+      "integrity": "sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
       }
     },
     "node_modules/dequal": {
@@ -7071,7 +7567,6 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
       "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -8851,6 +9346,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/robust-predicates": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
+      "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==",
+      "license": "Unlicense"
+    },
     "node_modules/rollup": {
       "version": "4.45.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.45.1.tgz",
@@ -8922,6 +9423,12 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
@@ -8981,7 +9488,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/saxes": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "@mediapipe/tasks-vision": "0.10.21",
     "@radix-ui/react-icons": "^1.3.2",
     "@radix-ui/themes": "^3.2.1",
+    "@types/d3": "^7.4.3",
+    "d3": "^7.9.0",
     "lucide-react": "^0.525.0",
     "next": "15.4.2",
     "react": "19.1.0",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,4 @@
-'use client';
+"use client";
 
 import { useState } from "react";
 import { Container, Flex, Box, Text, Heading, Tabs } from "@radix-ui/themes";
@@ -22,7 +22,7 @@ export default function Home() {
           <Heading size="8" align="center" mb="4">
             BlinkTrack
           </Heading>
-          <Text size="4" align="center" color="gray">
+          <Text size="4" align="center">
             Eye movement tracking with camera
           </Text>
         </Box>

--- a/src/components/CalibrationList.tsx
+++ b/src/components/CalibrationList.tsx
@@ -1,6 +1,6 @@
-'use client';
+"use client";
 
-import React, { useState } from 'react';
+import React, { useState } from "react";
 import {
   Box,
   Card,
@@ -12,10 +12,16 @@ import {
   TextField,
   Callout,
   AlertDialog,
-} from '@radix-ui/themes';
-import { TrashIcon, Pencil1Icon, CheckIcon, Cross2Icon, DownloadIcon } from '@radix-ui/react-icons';
-import { useCalibration } from '../contexts/CalibrationContext';
-import { Calibration } from '../lib/blink-detection/types';
+} from "@radix-ui/themes";
+import {
+  TrashIcon,
+  Pencil1Icon,
+  CheckIcon,
+  Cross2Icon,
+  DownloadIcon,
+} from "@radix-ui/react-icons";
+import { useCalibration } from "../contexts/CalibrationContext";
+import { Calibration } from "../lib/blink-detection/types";
 
 export function CalibrationList() {
   const {
@@ -27,7 +33,7 @@ export function CalibrationList() {
   } = useCalibration();
 
   const [editingId, setEditingId] = useState<string | null>(null);
-  const [editingName, setEditingName] = useState('');
+  const [editingName, setEditingName] = useState("");
   const [deleteConfirmId, setDeleteConfirmId] = useState<string | null>(null);
 
   const handleStartEdit = (calibration: Calibration) => {
@@ -40,16 +46,16 @@ export function CalibrationList() {
       try {
         updateCalibrationName(editingId, editingName.trim());
         setEditingId(null);
-        setEditingName('');
+        setEditingName("");
       } catch (error) {
-        console.error('Error updating calibration name:', error);
+        console.error("Error updating calibration name:", error);
       }
     }
   };
 
   const handleCancelEdit = () => {
     setEditingId(null);
-    setEditingName('');
+    setEditingName("");
   };
 
   const handleDelete = async (id: string) => {
@@ -57,16 +63,16 @@ export function CalibrationList() {
       deleteCalibration(id);
       setDeleteConfirmId(null);
     } catch (error) {
-      console.error('Error deleting calibration:', error);
+      console.error("Error deleting calibration:", error);
     }
   };
 
   const handleExport = (id: string) => {
     try {
       const exportData = exportCalibration(id);
-      const blob = new Blob([exportData], { type: 'application/json' });
+      const blob = new Blob([exportData], { type: "application/json" });
       const url = URL.createObjectURL(blob);
-      const a = document.createElement('a');
+      const a = document.createElement("a");
       a.href = url;
       a.download = `calibration-${id}.json`;
       document.body.appendChild(a);
@@ -74,17 +80,17 @@ export function CalibrationList() {
       document.body.removeChild(a);
       URL.revokeObjectURL(url);
     } catch (error) {
-      console.error('Error exporting calibration:', error);
+      console.error("Error exporting calibration:", error);
     }
   };
 
   const formatDate = (date: Date) => {
-    return date.toLocaleDateString('en-US', {
-      month: 'short',
-      day: 'numeric',
-      year: 'numeric',
-      hour: 'numeric',
-      minute: '2-digit',
+    return date.toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+      year: "numeric",
+      hour: "numeric",
+      minute: "2-digit",
       hour12: true,
     });
   };
@@ -93,11 +99,10 @@ export function CalibrationList() {
     return (
       <Box>
         <Callout.Root>
-          <Callout.Icon>
-            👁️
-          </Callout.Icon>
+          <Callout.Icon>👁️</Callout.Icon>
           <Callout.Text>
-            No calibrations found. Create your first calibration to start using blink detection.
+            No calibrations found. Create your first calibration to start using
+            blink detection.
           </Callout.Text>
         </Callout.Root>
       </Box>
@@ -108,7 +113,7 @@ export function CalibrationList() {
     <Box>
       <Flex direction="column" gap="3">
         {calibrations.map((calibration) => (
-          <Card key={calibration.id} style={{ padding: '16px' }}>
+          <Card key={calibration.id} style={{ padding: "16px" }}>
             <Flex direction="column" gap="3">
               {/* Header with name and actions */}
               <Flex justify="between" align="center">
@@ -120,8 +125,8 @@ export function CalibrationList() {
                         onChange={(e) => setEditingName(e.target.value)}
                         style={{ flex: 1 }}
                         onKeyDown={(e) => {
-                          if (e.key === 'Enter') handleSaveEdit();
-                          if (e.key === 'Escape') handleCancelEdit();
+                          if (e.key === "Enter") handleSaveEdit();
+                          if (e.key === "Escape") handleCancelEdit();
                         }}
                       />
                       <IconButton
@@ -195,20 +200,22 @@ export function CalibrationList() {
               {/* Calibration details */}
               <Flex direction="column" gap="2">
                 <Flex justify="between" align="center">
-                  <Text size="2" color="gray">
+                  <Text size="2">
                     Created: {formatDate(calibration.createdAt)}
                   </Text>
-                  <Text size="2" color="gray">
+                  <Text size="2">
                     EAR Threshold: {calibration.earThreshold.toFixed(3)}
                   </Text>
                 </Flex>
 
                 <Flex justify="between" align="center">
-                  <Text size="2" color="gray">
-                    Accuracy: {(calibration.metadata.accuracy * 100).toFixed(1)}%
+                  <Text size="2">
+                    Accuracy: {(calibration.metadata.accuracy * 100).toFixed(1)}
+                    %
                   </Text>
-                  <Text size="2" color="gray">
-                    Blinks: {calibration.metadata.totalBlinksDetected}/{calibration.metadata.totalBlinksRequested}
+                  <Text size="2">
+                    Blinks: {calibration.metadata.totalBlinksDetected}/
+                    {calibration.metadata.totalBlinksRequested}
                   </Text>
                 </Flex>
               </Flex>
@@ -225,14 +232,13 @@ export function CalibrationList() {
         <AlertDialog.Content style={{ maxWidth: 450 }}>
           <AlertDialog.Title>Delete Calibration</AlertDialog.Title>
           <AlertDialog.Description>
-            Are you sure you want to delete this calibration? This action cannot be undone.
+            Are you sure you want to delete this calibration? This action cannot
+            be undone.
           </AlertDialog.Description>
 
           <Flex gap="3" mt="4" justify="end">
             <AlertDialog.Cancel>
-              <Button variant="soft" color="gray">
-                Cancel
-              </Button>
+              <Button variant="soft">Cancel</Button>
             </AlertDialog.Cancel>
             <AlertDialog.Action>
               <Button

--- a/src/components/CalibrationManager.tsx
+++ b/src/components/CalibrationManager.tsx
@@ -1,6 +1,6 @@
-'use client';
+"use client";
 
-import React, { useState } from 'react';
+import React, { useState } from "react";
 import {
   Box,
   Flex,
@@ -10,30 +10,31 @@ import {
   Tabs,
   Card,
   Callout,
-} from '@radix-ui/themes';
-import { PlusIcon, EyeOpenIcon } from '@radix-ui/react-icons';
-import { useCalibration } from '../contexts/CalibrationContext';
-import { CalibrationList } from './CalibrationList';
-import { CalibrationFlow } from './CalibrationFlow';
+} from "@radix-ui/themes";
+import { PlusIcon, EyeOpenIcon } from "@radix-ui/react-icons";
+import { useCalibration } from "../contexts/CalibrationContext";
+import { CalibrationList } from "./CalibrationList";
+import { CalibrationFlow } from "./CalibrationFlow";
 
 export function CalibrationManager() {
-  const { calibrations, hasActiveCalibration, isCalibrating } = useCalibration();
+  const { calibrations, hasActiveCalibration, isCalibrating } =
+    useCalibration();
   const [showCalibrationFlow, setShowCalibrationFlow] = useState(false);
-  const [activeTab, setActiveTab] = useState('list');
+  const [activeTab, setActiveTab] = useState("list");
 
   const handleStartNewCalibration = () => {
     setShowCalibrationFlow(true);
-    setActiveTab('calibrate');
+    setActiveTab("calibrate");
   };
 
   const handleCalibrationComplete = () => {
     setShowCalibrationFlow(false);
-    setActiveTab('list');
+    setActiveTab("list");
   };
 
   const handleCalibrationCancel = () => {
     setShowCalibrationFlow(false);
-    setActiveTab('list');
+    setActiveTab("list");
   };
 
   if (showCalibrationFlow || isCalibrating) {
@@ -52,9 +53,7 @@ export function CalibrationManager() {
         <Flex justify="between" align="center">
           <Box>
             <Heading size="6">Calibration Management</Heading>
-            <Text size="3" color="gray">
-              Manage your blink detection calibrations
-            </Text>
+            <Text size="3">Manage your blink detection calibrations</Text>
           </Box>
           <Button size="3" onClick={handleStartNewCalibration}>
             <PlusIcon />
@@ -74,11 +73,10 @@ export function CalibrationManager() {
           </Callout.Root>
         ) : (
           <Callout.Root color="orange">
-            <Callout.Icon>
-              ⚠️
-            </Callout.Icon>
+            <Callout.Icon>⚠️</Callout.Icon>
             <Callout.Text>
-              No active calibration. Create a calibration to start using blink detection.
+              No active calibration. Create a calibration to start using blink
+              detection.
             </Callout.Text>
           </Callout.Root>
         )}
@@ -89,9 +87,7 @@ export function CalibrationManager() {
             <Tabs.Trigger value="list">
               Calibrations ({calibrations.length})
             </Tabs.Trigger>
-            <Tabs.Trigger value="info">
-              About Calibration
-            </Tabs.Trigger>
+            <Tabs.Trigger value="info">About Calibration</Tabs.Trigger>
           </Tabs.List>
 
           <Box pt="4">
@@ -100,43 +96,65 @@ export function CalibrationManager() {
             </Tabs.Content>
 
             <Tabs.Content value="info">
-              <Card style={{ padding: '20px' }}>
+              <Card style={{ padding: "20px" }}>
                 <Flex direction="column" gap="4">
                   <Heading size="4">How Calibration Works</Heading>
-                  
+
                   <Box>
-                    <Text size="3" weight="medium">What is EAR?</Text>
-                    <Text size="2" color="gray">
-                      Eye Aspect Ratio (EAR) measures the ratio between the height and width of your eye. 
-                      When you blink, this ratio drops significantly, allowing us to detect blinks reliably.
+                    <Text size="3" weight="medium">
+                      What is EAR?
+                    </Text>
+                    <Text size="2">
+                      Eye Aspect Ratio (EAR) measures the ratio between the
+                      height and width of your eye. When you blink, this ratio
+                      drops significantly, allowing us to detect blinks
+                      reliably.
                     </Text>
                   </Box>
 
                   <Box>
-                    <Text size="3" weight="medium">Calibration Process</Text>
-                    <Text size="2" color="gray">
-                      During calibration, you&apos;ll blink 10 times at 2-second intervals. 
-                      The system analyzes your blink patterns to determine the optimal EAR threshold 
-                      for your eyes, lighting conditions, and camera setup.
+                    <Text size="3" weight="medium">
+                      Calibration Process
+                    </Text>
+                    <Text size="2">
+                      During calibration, you&apos;ll blink 10 times at 2-second
+                      intervals. The system analyzes your blink patterns to
+                      determine the optimal EAR threshold for your eyes,
+                      lighting conditions, and camera setup.
                     </Text>
                   </Box>
 
                   <Box>
-                    <Text size="3" weight="medium">Why Calibrate?</Text>
-                    <Text size="2" color="gray">
-                      Everyone&apos;s eyes are different, and lighting conditions vary. 
-                      Calibration ensures the blink detection works accurately for your specific setup, 
-                      reducing false positives and missed blinks.
+                    <Text size="3" weight="medium">
+                      Why Calibrate?
+                    </Text>
+                    <Text size="2">
+                      Everyone&apos;s eyes are different, and lighting
+                      conditions vary. Calibration ensures the blink detection
+                      works accurately for your specific setup, reducing false
+                      positives and missed blinks.
                     </Text>
                   </Box>
 
                   <Box>
-                    <Text size="3" weight="medium">Best Practices</Text>
-                    <ul style={{ margin: '8px 0', paddingLeft: '20px' }}>
-                      <li><Text size="2" color="gray">Use good, consistent lighting</Text></li>
-                      <li><Text size="2" color="gray">Look directly at the camera</Text></li>
-                      <li><Text size="2" color="gray">Blink naturally when prompted</Text></li>
-                      <li><Text size="2" color="gray">Recalibrate if you change your setup</Text></li>
+                    <Text size="3" weight="medium">
+                      Best Practices
+                    </Text>
+                    <ul style={{ margin: "8px 0", paddingLeft: "20px" }}>
+                      <li>
+                        <Text size="2">Use good, consistent lighting</Text>
+                      </li>
+                      <li>
+                        <Text size="2">Look directly at the camera</Text>
+                      </li>
+                      <li>
+                        <Text size="2">Blink naturally when prompted</Text>
+                      </li>
+                      <li>
+                        <Text size="2">
+                          Recalibrate if you change your setup
+                        </Text>
+                      </li>
                     </ul>
                   </Box>
                 </Flex>

--- a/src/components/Camera.tsx
+++ b/src/components/Camera.tsx
@@ -1,19 +1,27 @@
-'use client';
+"use client";
 
-import React, { useState, useCallback, useRef, useEffect } from 'react';
-import { Box, Button, Text, Flex, Badge, Card, Callout } from '@radix-ui/themes';
-import { useCalibration } from '../contexts/CalibrationContext';
-import { useCamera } from '../hooks/useCamera';
-import { useBlinkDetection } from '../hooks/useBlinkDetection';
-import { useFrameProcessor } from '../hooks/useFrameProcessor';
-import { VideoCanvas } from './VideoCanvas';
+import React, { useState, useCallback, useRef, useEffect } from "react";
+import {
+  Box,
+  Button,
+  Text,
+  Flex,
+  Badge,
+  Card,
+  Callout,
+} from "@radix-ui/themes";
+import { useCalibration } from "../contexts/CalibrationContext";
+import { useCamera } from "../hooks/useCamera";
+import { useBlinkDetection } from "../hooks/useBlinkDetection";
+import { useFrameProcessor } from "../hooks/useFrameProcessor";
+import { VideoCanvas } from "./VideoCanvas";
 
 export function Camera() {
   const { canStartDetection, activeCalibration } = useCalibration();
   const [isInitialized, setIsInitialized] = useState(false);
-  
+
   const canvasRef = useRef<HTMLCanvasElement>(null);
-  
+
   const {
     stream,
     videoRef,
@@ -23,7 +31,7 @@ export function Camera() {
     hasPermission,
     isLoading: isCameraLoading,
   } = useCamera();
-  
+
   const {
     blinkCount,
     currentEAR,
@@ -47,20 +55,20 @@ export function Camera() {
       }
 
       const video = videoRef.current;
-      
+
       // Wait for video to be ready
       if (video.readyState < 2) {
         await new Promise<void>((resolve) => {
           const handleCanPlay = () => {
-            video.removeEventListener('canplay', handleCanPlay);
+            video.removeEventListener("canplay", handleCanPlay);
             resolve();
           };
-          video.addEventListener('canplay', handleCanPlay);
+          video.addEventListener("canplay", handleCanPlay);
         });
       }
 
       // Small delay to ensure stable video feed
-      await new Promise(resolve => setTimeout(resolve, 200));
+      await new Promise((resolve) => setTimeout(resolve, 200));
 
       if (!mounted) return;
 
@@ -72,7 +80,7 @@ export function Camera() {
             setIsInitialized(true);
           }
         } catch (err) {
-          console.error('Failed to start detection:', err);
+          console.error("Failed to start detection:", err);
         }
       }
     };
@@ -103,7 +111,7 @@ export function Camera() {
     try {
       await startCamera();
     } catch (error) {
-      console.error('Failed to start camera:', error);
+      console.error("Failed to start camera:", error);
     }
   }, [startCamera]);
 
@@ -130,8 +138,8 @@ export function Camera() {
         )}
 
         {!hasPermission && !isCameraLoading && (
-          <Button 
-            onClick={handleStartCamera} 
+          <Button
+            onClick={handleStartCamera}
             size="3"
             disabled={isCameraLoading || !canStartDetection()}
           >
@@ -139,9 +147,7 @@ export function Camera() {
           </Button>
         )}
 
-        {isCameraLoading && (
-          <Text>Requesting camera permission...</Text>
-        )}
+        {isCameraLoading && <Text>Requesting camera permission...</Text>}
 
         {error && (
           <Text color="red" size="2">
@@ -153,41 +159,62 @@ export function Camera() {
           <Box>
             <Flex direction="column" align="center" gap="3">
               {/* Live Metrics Display */}
-              <Card style={{ padding: '16px', minWidth: '300px' }}>
+              <Card style={{ padding: "16px", minWidth: "300px" }}>
                 <Flex direction="column" gap="2">
                   <Flex justify="between" align="center">
-                    <Text size="2" weight="medium">Blink Count:</Text>
+                    <Text size="2" weight="medium">
+                      Blink Count:
+                    </Text>
                     <Badge color={isBlinking ? "green" : "gray"} size="2">
                       {blinkCount}
                     </Badge>
                   </Flex>
                   <Flex justify="between" align="center">
-                    <Text size="2" weight="medium">EAR Score:</Text>
-                    <Badge color={currentEAR < (activeCalibration?.earThreshold || 0.25) ? "orange" : "blue"} size="2">
+                    <Text size="2" weight="medium">
+                      EAR Score:
+                    </Text>
+                    <Badge
+                      color={
+                        currentEAR < (activeCalibration?.earThreshold || 0.25)
+                          ? "orange"
+                          : "blue"
+                      }
+                      size="2"
+                    >
                       {currentEAR.toFixed(3)}
                     </Badge>
                   </Flex>
                   {activeCalibration && (
                     <Flex justify="between" align="center">
-                      <Text size="2" weight="medium">Threshold:</Text>
-                      <Badge color="gray" size="2">
+                      <Text size="2" weight="medium">
+                        Threshold:
+                      </Text>
+                      <Badge size="2">
                         {activeCalibration.earThreshold.toFixed(3)}
                       </Badge>
                     </Flex>
                   )}
                   <Flex justify="between" align="center">
-                    <Text size="2" weight="medium">Status:</Text>
-                    <Badge 
-                      color={!isDetectorReady ? "gray" : isBlinking ? "red" : "green"} 
+                    <Text size="2" weight="medium">
+                      Status:
+                    </Text>
+                    <Badge
+                      color={
+                        !isDetectorReady ? "gray" : isBlinking ? "red" : "green"
+                      }
                       size="2"
                     >
-                      {!isDetectorReady ? "Initializing..." : isBlinking ? "Blinking" : "Eyes Open"}
+                      {!isDetectorReady
+                        ? "Initializing..."
+                        : isBlinking
+                        ? "Blinking"
+                        : "Eyes Open"}
                     </Badge>
                   </Flex>
                 </Flex>
               </Card>
 
-              <VideoCanvas 
+              <VideoCanvas
                 videoRef={videoRef}
                 canvasRef={canvasRef}
                 showCanvas={showDebugOverlay}
@@ -195,32 +222,32 @@ export function Camera() {
 
               <Flex gap="2" justify="center" wrap="wrap">
                 {stream && (
-                  <Button 
-                    onClick={handleStopCamera} 
-                    size="3" 
-                    variant="soft" 
+                  <Button
+                    onClick={handleStopCamera}
+                    size="3"
+                    variant="soft"
                     color="red"
                   >
                     Stop Camera
                   </Button>
                 )}
-                
-                <Button 
-                  onClick={resetBlinkCounter} 
-                  size="2" 
+
+                <Button
+                  onClick={resetBlinkCounter}
+                  size="2"
                   variant="soft"
                   disabled={!isDetectorReady}
                 >
                   Reset Counter
                 </Button>
 
-                <Button 
-                  onClick={toggleDebugOverlay} 
-                  size="2" 
+                <Button
+                  onClick={toggleDebugOverlay}
+                  size="2"
                   variant="soft"
                   disabled={!isDetectorReady}
                 >
-                  Toggle Debug: {showDebugOverlay ? 'ON' : 'OFF'}
+                  Toggle Debug: {showDebugOverlay ? "ON" : "OFF"}
                 </Button>
               </Flex>
             </Flex>

--- a/src/components/SessionCard.css
+++ b/src/components/SessionCard.css
@@ -1,0 +1,21 @@
+@keyframes pulse {
+  0% {
+    opacity: 1;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 0.6;
+    transform: scale(1.1);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.pulse-dot {
+  display: inline-block;
+  animation: pulse 2s ease-in-out infinite;
+  font-size: 1.2em;
+  line-height: 0;
+}

--- a/src/components/SessionCard.test.tsx
+++ b/src/components/SessionCard.test.tsx
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { SessionCard } from './SessionCard';
+import { SessionData } from '../lib/sessions/types';
+
+// Mock D3
+const mockElement = {
+  attr: vi.fn(function() { return this; }),
+  append: vi.fn(function() { return this; }),
+  datum: vi.fn(function() { return this; }),
+  transition: vi.fn(function() { return this; }),
+  duration: vi.fn(function() { return this; }),
+  ease: vi.fn(function() { return this; }),
+  node: vi.fn(() => ({ getTotalLength: vi.fn(() => 100) })),
+};
+
+vi.mock('d3', () => ({
+  select: vi.fn(() => ({
+    selectAll: vi.fn(() => ({ remove: vi.fn() })),
+    attr: vi.fn(function() { return this; }),
+    append: vi.fn((tag) => {
+      if (tag === 'g' || tag === 'path' || tag === 'defs') {
+        return mockElement;
+      }
+      return mockElement;
+    }),
+  })),
+  scaleLinear: vi.fn(() => {
+    const scale = vi.fn(() => 0);
+    scale.domain = vi.fn(() => scale);
+    scale.range = vi.fn(() => scale);
+    return scale;
+  }),
+  line: vi.fn(() => {
+    const lineFunc = vi.fn();
+    lineFunc.x = vi.fn(() => lineFunc);
+    lineFunc.y = vi.fn(() => lineFunc);
+    lineFunc.curve = vi.fn(() => lineFunc);
+    return lineFunc;
+  }),
+  area: vi.fn(() => {
+    const areaFunc = vi.fn();
+    areaFunc.x = vi.fn(() => areaFunc);
+    areaFunc.y0 = vi.fn(() => areaFunc);
+    areaFunc.y1 = vi.fn(() => areaFunc);
+    areaFunc.curve = vi.fn(() => areaFunc);
+    return areaFunc;
+  }),
+  max: vi.fn(() => 20),
+  curveMonotoneX: vi.fn(),
+  easeLinear: vi.fn(),
+}));
+
+const mockSession: SessionData = {
+  id: 'session-1',
+  startTime: new Date('2025-01-20T10:00:00'),
+  endTime: new Date('2025-01-20T11:30:00'),
+  isActive: false,
+  averageBlinkRate: 12,
+  blinkRateHistory: [
+    { timestamp: Date.now() - 5000, rate: 11 },
+    { timestamp: Date.now() - 4000, rate: 12 },
+    { timestamp: Date.now() - 3000, rate: 13 },
+  ],
+  quality: 'good',
+  fatigueAlertCount: 0,
+  duration: 5400,
+  totalBlinks: 1080,
+};
+
+describe('SessionCard', () => {
+  it('renders session information correctly', () => {
+    render(<SessionCard session={mockSession} />);
+
+    expect(screen.getByText('10:00 AM')).toBeInTheDocument();
+    expect(screen.getByText('12 blinks/min')).toBeInTheDocument();
+    expect(screen.getByText('Good quality')).toBeInTheDocument();
+    expect(screen.getByText('1h 30m')).toBeInTheDocument();
+    expect(screen.getByText('1080 total blinks')).toBeInTheDocument();
+  });
+
+  it('shows active badge with pulsing animation for active sessions', () => {
+    const activeSession = { ...mockSession, isActive: true };
+    render(<SessionCard session={activeSession} />);
+
+    const activeBadge = screen.getByText('Active');
+    expect(activeBadge).toBeInTheDocument();
+    
+    const pulseDot = activeBadge.parentElement?.querySelector('.pulse-dot');
+    expect(pulseDot).toBeInTheDocument();
+  });
+
+  it('displays fatigue alert count when present', () => {
+    const sessionWithAlerts = { ...mockSession, fatigueAlertCount: 2 };
+    render(<SessionCard session={sessionWithAlerts} />);
+
+    expect(screen.getByText('2 fatigue alerts')).toBeInTheDocument();
+  });
+
+  it('shows no fatigue alerts when count is zero', () => {
+    render(<SessionCard session={mockSession} />);
+
+    expect(screen.getByText('No fatigue alerts')).toBeInTheDocument();
+  });
+
+  it('displays quality badge with correct color', () => {
+    const { rerender } = render(<SessionCard session={mockSession} />);
+    expect(screen.getByText('Good quality')).toBeInTheDocument();
+
+    const fairSession = { ...mockSession, quality: 'fair' as const };
+    rerender(<SessionCard session={fairSession} />);
+    expect(screen.getByText('Fair quality')).toBeInTheDocument();
+
+    const poorSession = { ...mockSession, quality: 'poor' as const };
+    rerender(<SessionCard session={poorSession} />);
+    expect(screen.getByText('Poor quality')).toBeInTheDocument();
+  });
+
+  it('shows collecting data message for active session without data', () => {
+    const emptySession = {
+      ...mockSession,
+      isActive: true,
+      blinkRateHistory: [],
+    };
+    render(<SessionCard session={emptySession} />);
+
+    expect(screen.getByText('Collecting data...')).toBeInTheDocument();
+  });
+});

--- a/src/components/SessionCard.tsx
+++ b/src/components/SessionCard.tsx
@@ -1,48 +1,164 @@
-'use client';
+"use client";
 
-import React from 'react';
-import { Box, Card, Flex, Text, Badge } from '@radix-ui/themes';
-import { LineChart, Line, ResponsiveContainer, YAxis } from 'recharts';
-import { SessionData, formatSessionDuration } from '../lib/sessions/types';
-import { ClockIcon } from '@radix-ui/react-icons';
-import { Bell, BellOff } from 'lucide-react';
+import React, { useEffect, useRef } from "react";
+import { Box, Card, Flex, Text, Badge } from "@radix-ui/themes";
+import * as d3 from "d3";
+import { SessionData, formatSessionDuration } from "../lib/sessions/types";
+import { ClockIcon } from "@radix-ui/react-icons";
+import { Bell, BellOff } from "lucide-react";
+import "./SessionCard.css";
 
 interface SessionCardProps {
   session: SessionData;
 }
 
 export function SessionCard({ session }: SessionCardProps) {
+  const chartRef = useRef<SVGSVGElement>(null);
+  const [, forceUpdate] = React.useReducer(x => x + 1, 0);
+
+  // Update time every second for active sessions
+  useEffect(() => {
+    if (!session.isActive) return;
+
+    const interval = setInterval(() => {
+      forceUpdate();
+    }, 1000);
+
+    return () => clearInterval(interval);
+  }, [session.isActive]);
+
   const formatTime = (date: Date) => {
-    return date.toLocaleTimeString('en-US', {
-      hour: 'numeric',
-      minute: '2-digit',
+    return date.toLocaleTimeString("en-US", {
+      hour: "numeric",
+      minute: "2-digit",
       hour12: true,
     });
   };
 
-  const getQualityColor = (quality: 'good' | 'fair' | 'poor') => {
+  const getQualityColor = (quality: "good" | "fair" | "poor") => {
     switch (quality) {
-      case 'good':
-        return 'green';
-      case 'fair':
-        return 'amber';
-      case 'poor':
-        return 'red';
+      case "good":
+        return "green";
+      case "fair":
+        return "amber";
+      case "poor":
+        return "red";
     }
   };
 
+  const formatDynamicDuration = (startTime: Date) => {
+    const now = new Date();
+    const seconds = Math.floor((now.getTime() - startTime.getTime()) / 1000);
+    
+    if (seconds < 60) {
+      return `${seconds}s`;
+    }
+    
+    const minutes = Math.floor(seconds / 60);
+    if (minutes < 60) {
+      return `${minutes}m`;
+    }
+    
+    const hours = Math.floor(minutes / 60);
+    const remainingMinutes = minutes % 60;
+    return `${hours}h ${remainingMinutes}m`;
+  };
 
-  // Prepare chart data
-  const chartData = session.blinkRateHistory.map(point => ({
-    rate: point.rate,
-  }));
+  useEffect(() => {
+    if (!chartRef.current || session.blinkRateHistory.length === 0) return;
+
+    // Clear previous chart
+    d3.select(chartRef.current).selectAll("*").remove();
+
+    const margin = { top: 5, right: 5, bottom: 5, left: 5 };
+    const width = 200 - margin.left - margin.right;
+    const height = 60 - margin.top - margin.bottom;
+
+    const svg = d3.select(chartRef.current)
+      .attr("width", width + margin.left + margin.right)
+      .attr("height", height + margin.top + margin.bottom);
+
+    const g = svg.append("g")
+      .attr("transform", `translate(${margin.left},${margin.top})`);
+
+    // Prepare data
+    const data = session.blinkRateHistory.map((point, index) => ({
+      x: index,
+      y: point.rate
+    }));
+
+    // Set up scales
+    const xScale = d3.scaleLinear()
+      .domain([0, data.length - 1])
+      .range([0, width]);
+
+    const yScale = d3.scaleLinear()
+      .domain([0, Math.max(20, d3.max(data, d => d.y) || 20)])
+      .range([height, 0]);
+
+    // Create gradient
+    const gradient = svg.append("defs")
+      .append("linearGradient")
+      .attr("id", `gradient-${session.id}`)
+      .attr("gradientUnits", "userSpaceOnUse")
+      .attr("x1", 0).attr("y1", height)
+      .attr("x2", 0).attr("y2", 0);
+
+    gradient.append("stop")
+      .attr("offset", "0%")
+      .attr("stop-color", "var(--accent-9)")
+      .attr("stop-opacity", 0.05);
+
+    gradient.append("stop")
+      .attr("offset", "100%")
+      .attr("stop-color", "var(--accent-9)")
+      .attr("stop-opacity", 0.2);
+
+    // Create area
+    const area = d3.area<{ x: number; y: number }>()
+      .x(d => xScale(d.x))
+      .y0(height)
+      .y1(d => yScale(d.y))
+      .curve(d3.curveMonotoneX);
+
+    // Create line
+    const line = d3.line<{ x: number; y: number }>()
+      .x(d => xScale(d.x))
+      .y(d => yScale(d.y))
+      .curve(d3.curveMonotoneX);
+
+    // Add area
+    g.append("path")
+      .datum(data)
+      .attr("fill", `url(#gradient-${session.id})`)
+      .attr("d", area);
+
+    // Add line
+    const path = g.append("path")
+      .datum(data)
+      .attr("fill", "none")
+      .attr("stroke", "var(--accent-9)")
+      .attr("stroke-width", 2)
+      .attr("d", line);
+
+    // Animate the line drawing
+    const totalLength = path.node()?.getTotalLength() || 0;
+    path
+      .attr("stroke-dasharray", totalLength + " " + totalLength)
+      .attr("stroke-dashoffset", totalLength)
+      .transition()
+      .duration(1000)
+      .ease(d3.easeLinear)
+      .attr("stroke-dashoffset", 0);
+
+  }, [session.blinkRateHistory, session.id]);
 
   return (
     <Card
       style={{
-        padding: '20px',
-        border: session.isActive ? '2px solid #10b981' : 'none',
-        position: 'relative',
+        padding: "20px",
+        border: session.isActive ? "2px solid #10b981" : "none",
+        position: "relative",
       }}
     >
       <Flex direction="column" gap="3">
@@ -53,20 +169,23 @@ export function SessionCard({ session }: SessionCardProps) {
               {formatTime(session.startTime)}
             </Text>
             {session.isActive && (
-              <Badge color="green" size="2">
-                • Active
+              <Badge color="green" size="2" style={{ position: "relative" }}>
+                <span className="pulse-dot">•</span> Active
               </Badge>
             )}
           </Flex>
-          
+
           {/* Quality badges */}
           <Flex gap="2" align="center">
             <Badge color={getQualityColor(session.quality)} variant="soft">
-              {session.quality.charAt(0).toUpperCase() + session.quality.slice(1)} quality
+              {session.quality.charAt(0).toUpperCase() +
+                session.quality.slice(1)}{" "}
+              quality
             </Badge>
             {session.fatigueAlertCount > 0 ? (
               <Badge color="orange" variant="soft">
-                <Bell size={14} /> {session.fatigueAlertCount} fatigue alert{session.fatigueAlertCount > 1 ? 's' : ''}
+                <Bell size={14} /> {session.fatigueAlertCount} fatigue alert
+                {session.fatigueAlertCount > 1 ? "s" : ""}
               </Badge>
             ) : (
               <Badge color="green" variant="soft">
@@ -76,37 +195,36 @@ export function SessionCard({ session }: SessionCardProps) {
           </Flex>
         </Flex>
 
-        {/* Duration */}
-        {!session.isActive && session.duration && (
+        {/* Duration and Blinks */}
+        <Flex justify="between" align="center">
           <Flex align="center" gap="2">
             <ClockIcon />
-            <Text size="2" color="gray">
-              {formatSessionDuration(session.duration)}
+            <Text size="2">
+              {session.isActive 
+                ? formatDynamicDuration(session.startTime)
+                : session.duration 
+                  ? formatSessionDuration(session.duration)
+                  : "0m"
+              }
             </Text>
           </Flex>
-        )}
+          {session.totalBlinks !== undefined && (
+            <Text size="2" color="gray">
+              {session.totalBlinks} total blinks
+            </Text>
+          )}
+        </Flex>
 
         {/* Main content area */}
         <Flex justify="between" align="center" gap="4">
           {/* Mini chart */}
-          <Box style={{ width: '200px', height: '60px' }}>
-            {chartData.length > 0 ? (
-              <ResponsiveContainer width="100%" height="100%">
-                <LineChart data={chartData} margin={{ top: 5, right: 5, bottom: 5, left: 5 }}>
-                  <YAxis hide domain={[0, 20]} />
-                  <Line
-                    type="monotone"
-                    dataKey="rate"
-                    stroke="#3b82f6"
-                    strokeWidth={2}
-                    dot={false}
-                  />
-                </LineChart>
-              </ResponsiveContainer>
+          <Box style={{ width: "200px", height: "60px" }}>
+            {session.blinkRateHistory.length > 0 ? (
+              <svg ref={chartRef}></svg>
             ) : (
-              <Flex align="center" justify="center" style={{ height: '100%' }}>
-                <Text size="2" color="gray">
-                  {session.isActive ? 'Collecting data...' : 'No data'}
+              <Flex align="center" justify="center" style={{ height: "100%" }}>
+                <Text size="2">
+                  {session.isActive ? "Collecting data..." : "No data"}
                 </Text>
               </Flex>
             )}
@@ -116,10 +234,9 @@ export function SessionCard({ session }: SessionCardProps) {
           <Text
             size="6"
             weight="bold"
-            color="gray"
-            style={{ 
-              minWidth: '120px',
-              textAlign: 'right',
+            style={{
+              minWidth: "120px",
+              textAlign: "right",
             }}
           >
             {Math.round(session.averageBlinkRate)} blinks/min

--- a/src/components/SessionsView.tsx
+++ b/src/components/SessionsView.tsx
@@ -35,7 +35,7 @@ export function SessionsView() {
           <Heading size="6" mb="2">
             Screen Session Tracking
           </Heading>
-          <Text size="3" color="gray">
+          <Text size="3">
             Monitor your screen time and eye fatigue patterns
           </Text>
         </Box>
@@ -120,15 +120,21 @@ export function SessionsView() {
                   </Flex>
                   <Flex gap="2" align="center">
                     <Text size="2">•</Text>
-                    <Text size="2">Sessions continue through interruptions up to 10 seconds</Text>
+                    <Text size="2">
+                      Sessions continue through interruptions up to 10 seconds
+                    </Text>
                   </Flex>
                   <Flex gap="2" align="center">
                     <Text size="2">•</Text>
-                    <Text size="2">Blink rate targets: Good (12+), Fair (8-11), Poor (&lt;8)</Text>
+                    <Text size="2">
+                      Blink rate targets: Good (12+), Fair (8-11), Poor (&lt;8)
+                    </Text>
                   </Flex>
                   <Flex gap="2" align="center">
                     <Text size="2">•</Text>
-                    <Text size="2">No camera footage is displayed or stored</Text>
+                    <Text size="2">
+                      No camera footage is displayed or stored
+                    </Text>
                   </Flex>
                 </Flex>
               </Box>

--- a/src/lib/sessions/types.ts
+++ b/src/lib/sessions/types.ts
@@ -8,6 +8,7 @@ export interface SessionData {
   quality: 'good' | 'fair' | 'poor';
   fatigueAlertCount: number;
   duration?: number; // in seconds
+  totalBlinks?: number;
 }
 
 export interface BlinkRatePoint {


### PR DESCRIPTION
## Summary
- Replace Recharts with D3 for session card mini charts
- Add pulsing animation for active session indicator (EYE-37)
- Display total blink count on session cards (EYE-35)
- Show dynamic duration for active sessions
- Only store sessions longer than 2 minutes (EYE-35)
- Add subtle gradient background to charts (EYE-34)

## Test plan
- [x] D3 charts render correctly with gradient fill
- [x] Pulsing animation works on active sessions
- [x] Total blink count displays
- [x] Duration updates in real-time for active sessions
- [x] Sessions under 2 minutes are not stored

🤖 Generated with [Claude Code](https://claude.ai/code)