### PR TITLE
feat: Link sessions to calibrations in data model (EYE-33)

### DIFF
--- a/src/components/SessionCard.css
+++ b/src/components/SessionCard.css
@@ -1,0 +1,19 @@
+@keyframes pulse {
+  0% {
+    opacity: 1;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 0.5;
+    transform: scale(1.2);
+  }
+  100% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.pulse-dot {
+  display: inline-block;
+  animation: pulse 2s ease-in-out infinite;
+}

--- a/src/components/SessionCard.test.tsx
+++ b/src/components/SessionCard.test.tsx
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Theme } from '@radix-ui/themes';
+import { SessionCard } from './SessionCard';
+import { SessionData } from '../lib/sessions/types';
+
+// Mock the CalibrationContext
+const mockCalibrations = [
+  {
+    id: 'calibration-1',
+    name: 'Default Calibration',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    isActive: true,
+    earThreshold: 0.25,
+    metadata: {
+      totalBlinksRequested: 0,
+      totalBlinksDetected: 0,
+      accuracy: 0,
+      averageBlinkInterval: 0,
+      minEarValue: 0,
+      maxEarValue: 0,
+    },
+    rawData: {
+      timestamps: [],
+      earValues: [],
+      blinkEvents: [],
+    },
+  },
+];
+
+vi.mock('../contexts/CalibrationContext', () => ({
+  useCalibration: () => ({
+    calibrations: mockCalibrations,
+  }),
+}));
+
+// Mock D3
+const createD3Mock = () => {
+  const mock: Record<string, ReturnType<typeof vi.fn>> = {
+    append: vi.fn(),
+    attr: vi.fn(),
+    datum: vi.fn(),
+    selectAll: vi.fn(),
+    transition: vi.fn(),
+    duration: vi.fn(),
+    ease: vi.fn(),
+    node: vi.fn(() => ({ getTotalLength: vi.fn(() => 100) })),
+  };
+  
+  // Make all methods chainable
+  Object.keys(mock).forEach(key => {
+    if (key === 'selectAll') {
+      mock[key].mockReturnValue({ remove: vi.fn() });
+    } else if (key === 'node') {
+      // node returns the DOM element, not the selection
+    } else {
+      mock[key].mockReturnValue(mock);
+    }
+  });
+  
+  return mock;
+};
+
+// Create chainable mocks for area and line
+const createChainableMock = () => {
+  const mock: ReturnType<typeof vi.fn> & Record<string, ReturnType<typeof vi.fn>> = Object.assign(vi.fn(), {
+    x: vi.fn(),
+    y: vi.fn(),
+    y0: vi.fn(),
+    y1: vi.fn(),
+    curve: vi.fn(),
+  });
+  mock.x = vi.fn(() => mock);
+  mock.y = vi.fn(() => mock);
+  mock.y0 = vi.fn(() => mock);
+  mock.y1 = vi.fn(() => mock);
+  mock.curve = vi.fn(() => mock);
+  return mock;
+};
+
+vi.mock('d3', () => ({
+  select: vi.fn(() => createD3Mock()),
+  scaleLinear: vi.fn(() => ({
+    domain: vi.fn(() => ({ 
+      range: vi.fn(() => vi.fn()),
+    })),
+  })),
+  max: vi.fn(() => 20),
+  area: vi.fn(() => createChainableMock()),
+  line: vi.fn(() => createChainableMock()),
+  curveMonotoneX: {},
+  easeLinear: {},
+}));
+
+// Mock CSS file
+vi.mock('./SessionCard.css', () => ({}));
+
+describe('SessionCard', () => {
+  const mockSession: SessionData = {
+    id: 'session-1',
+    startTime: new Date(),
+    isActive: false,
+    averageBlinkRate: 12,
+    blinkRateHistory: [
+      { timestamp: Date.now() - 60000, rate: 10 },
+      { timestamp: Date.now() - 30000, rate: 12 },
+      { timestamp: Date.now(), rate: 14 },
+    ],
+    quality: 'good',
+    fatigueAlertCount: 0,
+    duration: 3600, // 1 hour
+    calibrationId: 'calibration-1',
+  };
+
+  const renderSessionCard = (session: SessionData) => {
+    return render(
+      <Theme>
+        <SessionCard session={session} />
+      </Theme>
+    );
+  };
+
+  it('displays calibration name when session has calibrationId', () => {
+    renderSessionCard(mockSession);
+    
+    expect(screen.getByText('• Default Calibration')).toBeInTheDocument();
+  });
+
+  it('does not display calibration info when session has no calibrationId', () => {
+    const sessionWithoutCalibration = { ...mockSession, calibrationId: undefined };
+    renderSessionCard(sessionWithoutCalibration);
+    
+    expect(screen.queryByText(/Default Calibration/)).not.toBeInTheDocument();
+  });
+
+  it('displays "Unknown calibration" when calibrationId does not match any calibration', () => {
+    const sessionWithUnknownCalibration = { ...mockSession, calibrationId: 'unknown-id' };
+    renderSessionCard(sessionWithUnknownCalibration);
+    
+    expect(screen.getByText('• Unknown calibration')).toBeInTheDocument();
+  });
+});

--- a/src/contexts/SessionContext.tsx
+++ b/src/contexts/SessionContext.tsx
@@ -50,6 +50,7 @@ const generateMockSessions = (): SessionData[] => {
       quality: "poor",
       fatigueAlertCount: 2,
       duration: 5400, // 1h 30m
+      calibrationId: "default-calibration-1",
     },
     {
       id: "session-2",
@@ -61,6 +62,7 @@ const generateMockSessions = (): SessionData[] => {
       quality: "fair",
       fatigueAlertCount: 0,
       duration: 5400, // 1h 30m
+      calibrationId: "default-calibration-1",
     },
   ];
 };
@@ -99,13 +101,12 @@ export function SessionProvider({ children }: SessionProviderProps) {
   const { activeCalibration } = useCalibration();
 
   // Camera and blink detection hooks
-  const { stream, videoRef, startCamera, stopCamera, hasPermission } =
+  const { stream, videoRef, startCamera, stopCamera } =
     useCamera();
 
   const {
     blinkCount,
     currentEAR,
-    isReady: isDetectorReady,
     start: startDetection,
     stop: stopDetection,
     processFrame,
@@ -175,7 +176,7 @@ export function SessionProvider({ children }: SessionProviderProps) {
     return () => {
       mounted = false;
     };
-  }, [stream, isTracking, startDetection, isInitialized]);
+  }, [stream, isTracking, startDetection, isInitialized, videoRef]);
 
   // Set video stream
   useEffect(() => {
@@ -272,13 +273,14 @@ export function SessionProvider({ children }: SessionProviderProps) {
       blinkRateHistory: [],
       quality: "good",
       fatigueAlertCount: 0,
+      calibrationId: activeCalibration?.id,
     };
 
     setActiveSession(newSession);
     setSessions((prev) => [newSession, ...prev]);
     blinkCountRef.current = blinkCount;
     sessionStartTimeRef.current = Date.now();
-  }, [isTracking, activeSession, isFaceDetected, blinkCount]);
+  }, [isTracking, activeSession, isFaceDetected, blinkCount, activeCalibration]);
 
   const stopSession = useCallback(() => {
     if (!activeSession) return;

--- a/src/lib/sessions/session-calibration.test.ts
+++ b/src/lib/sessions/session-calibration.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { SessionData } from './types';
+
+describe('Session-Calibration Link', () => {
+  it('should include calibrationId in SessionData type', () => {
+    const session: SessionData = {
+      id: 'test-session',
+      startTime: new Date(),
+      isActive: true,
+      averageBlinkRate: 10,
+      blinkRateHistory: [],
+      quality: 'good',
+      fatigueAlertCount: 0,
+      calibrationId: 'test-calibration-id',
+    };
+
+    expect(session.calibrationId).toBe('test-calibration-id');
+  });
+
+  it('should allow SessionData without calibrationId', () => {
+    const session: SessionData = {
+      id: 'test-session',
+      startTime: new Date(),
+      isActive: true,
+      averageBlinkRate: 10,
+      blinkRateHistory: [],
+      quality: 'good',
+      fatigueAlertCount: 0,
+    };
+
+    expect(session.calibrationId).toBeUndefined();
+  });
+});

--- a/src/lib/sessions/types.ts
+++ b/src/lib/sessions/types.ts
@@ -8,6 +8,8 @@ export interface SessionData {
   quality: 'good' | 'fair' | 'poor';
   fatigueAlertCount: number;
   duration?: number; // in seconds
+  calibrationId?: string; // ID of the calibration used for this session
+  totalBlinks?: number; // Total number of blinks in the session
 }
 
 export interface BlinkRatePoint {


### PR DESCRIPTION
## Summary
- Add calibrationId field to SessionData interface to link sessions to their calibrations
- Update SessionContext to automatically link new sessions to the active calibration
- Display calibration name on SessionCard for better user context

## Changes
- **Data Model Enhancement**
  - Added `calibrationId?: string` field to SessionData interface
  - Added `totalBlinks?: number` field for compatibility with updated SessionCard
  
- **Session Creation**
  - SessionContext now links new sessions to activeCalibration?.id
  - Mock sessions include sample calibrationId values
  
- **UI Improvements**
  - SessionCard displays calibration name instead of raw ID
  - Falls back to "Unknown calibration" if calibration not found
  - Calibration info shown next to session duration

## Test Plan
- [x] Create a new calibration and set it as active
- [x] Start a new session and verify it links to the active calibration
- [x] Check SessionCard displays calibration name correctly
- [x] Verify sessions work without calibrationId (backwards compatibility)
- [x] Run unit tests for session-calibration linking
- [x] Ensure build passes without errors

## Related Issue
- Implements EYE-33: Sessions should have links towards the calibrations that produced them

🤖 Generated with [Claude Code](https://claude.ai/code)