### PR TITLE
feat: implement navbar navigation with dark/light/system theme toggle (EYE-36)

### DIFF
--- a/src/app/calibration/page.tsx
+++ b/src/app/calibration/page.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import { CalibrationManager } from "../../components/CalibrationManager";
+
+export default function CalibrationPage() {
+  return <CalibrationManager />;
+}

--- a/src/app/client-layout.tsx
+++ b/src/app/client-layout.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { Theme } from "@radix-ui/themes";
+import { useTheme } from "../contexts/ThemeContext";
+import { Navbar } from "../components/Navbar";
+
+export function ClientLayout({ children }: { children: React.ReactNode }) {
+  const { resolvedTheme } = useTheme();
+
+  return (
+    <Theme appearance={resolvedTheme} accentColor="indigo" grayColor="mauve">
+      <Navbar />
+      {children}
+    </Theme>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,7 +1,8 @@
 import type { Metadata } from "next";
-import { Theme } from "@radix-ui/themes";
 import { CalibrationProvider } from "../contexts/CalibrationContext";
 import { SessionProvider } from "../contexts/SessionContext";
+import { ThemeProvider } from "../contexts/ThemeContext";
+import { ClientLayout } from "./client-layout";
 import "@radix-ui/themes/styles.css";
 
 export const metadata: Metadata = {
@@ -17,11 +18,13 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body>
-        <Theme appearance="dark" accentColor="indigo" grayColor="mauve">
+        <ThemeProvider>
           <CalibrationProvider>
-            <SessionProvider>{children}</SessionProvider>
+            <SessionProvider>
+              <ClientLayout>{children}</ClientLayout>
+            </SessionProvider>
           </CalibrationProvider>
-        </Theme>
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/src/components/Navbar.test.tsx
+++ b/src/components/Navbar.test.tsx
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Theme } from '@radix-ui/themes';
+import { Navbar } from './Navbar';
+import { ThemeProvider } from '../contexts/ThemeContext';
+
+// Mock next/navigation
+vi.mock('next/navigation', () => ({
+  usePathname: vi.fn(() => '/'),
+}));
+
+// Mock ResizeObserver
+global.ResizeObserver = vi.fn().mockImplementation(() => ({
+  observe: vi.fn(),
+  unobserve: vi.fn(),
+  disconnect: vi.fn(),
+}));
+
+// Mock localStorage
+const mockLocalStorage = {
+  getItem: vi.fn(),
+  setItem: vi.fn(),
+  removeItem: vi.fn(),
+  clear: vi.fn(),
+};
+Object.defineProperty(window, 'localStorage', {
+  value: mockLocalStorage,
+  writable: true,
+});
+
+// Mock matchMedia
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation(query => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});
+
+function renderNavbar() {
+  return render(
+    <Theme>
+      <ThemeProvider>
+        <Navbar />
+      </ThemeProvider>
+    </Theme>
+  );
+}
+
+describe('Navbar', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the navbar with all navigation links', () => {
+    renderNavbar();
+    
+    expect(screen.getByText('BlinkTrack')).toBeInTheDocument();
+    expect(screen.getByText('Sessions')).toBeInTheDocument();
+    expect(screen.getByText('Calibration')).toBeInTheDocument();
+    expect(screen.getByText('Account')).toBeInTheDocument();
+  });
+
+  it('shows theme toggle button', () => {
+    renderNavbar();
+    
+    const themeButton = screen.getByRole('button');
+    expect(themeButton).toBeInTheDocument();
+  });
+
+  it('opens theme dropdown when clicked', async () => {
+    const user = userEvent.setup();
+    renderNavbar();
+    
+    const themeButton = screen.getByRole('button');
+    await user.click(themeButton);
+    
+    expect(screen.getByText('Light')).toBeInTheDocument();
+    expect(screen.getByText('Dark')).toBeInTheDocument();
+    expect(screen.getByText('System')).toBeInTheDocument();
+  });
+
+  it('changes theme when option is selected', async () => {
+    const user = userEvent.setup();
+    renderNavbar();
+    
+    const themeButton = screen.getByRole('button');
+    await user.click(themeButton);
+    
+    const lightOption = screen.getByText('Light');
+    await user.click(lightOption);
+    
+    expect(mockLocalStorage.setItem).toHaveBeenCalledWith('theme', 'light');
+  });
+
+  it('highlights current page link', async () => {
+    const nextNavigation = await import('next/navigation');
+    const { usePathname } = vi.mocked(nextNavigation);
+    usePathname.mockReturnValue('/calibration');
+    
+    renderNavbar();
+    
+    const calibrationLink = screen.getByText('Calibration');
+    const calibrationLinkElement = calibrationLink.closest('a');
+    expect(calibrationLinkElement).toHaveStyle({ color: 'var(--accent-11)' });
+  });
+});

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import React from "react";
+import { Flex, Text, IconButton, DropdownMenu } from "@radix-ui/themes";
+import { SunIcon, MoonIcon, LaptopIcon } from "@radix-ui/react-icons";
+import { useTheme } from "../contexts/ThemeContext";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+export function Navbar() {
+  const { theme, setTheme } = useTheme();
+  const pathname = usePathname();
+
+  const getThemeIcon = () => {
+    if (theme === "system") return <LaptopIcon />;
+    if (theme === "dark") return <MoonIcon />;
+    return <SunIcon />;
+  };
+
+  const navLinks = [
+    { href: "/", label: "Sessions" },
+    { href: "/calibration", label: "Calibration" },
+    { href: "/account", label: "Account" },
+  ];
+
+  return (
+    <Flex
+      align="center"
+      justify="between"
+      px="6"
+      py="3"
+      style={{ 
+        borderBottom: "1px solid var(--gray-a5)",
+        backgroundColor: "var(--color-background)",
+      }}
+    >
+      <Flex align="center" gap="6">
+        <Link href="/" style={{ textDecoration: "none" }}>
+          <Text size="5" weight="bold" style={{ color: "var(--gray-12)" }}>
+            BlinkTrack
+          </Text>
+        </Link>
+        
+        <Flex gap="4">
+          {navLinks.map((link) => (
+            <Link
+              key={link.href}
+              href={link.href}
+              style={{
+                textDecoration: "none",
+                color: pathname === link.href ? "var(--accent-11)" : "var(--gray-11)",
+                fontWeight: pathname === link.href ? "500" : "400",
+              }}
+            >
+              <Text size="3">{link.label}</Text>
+            </Link>
+          ))}
+        </Flex>
+      </Flex>
+
+      <DropdownMenu.Root>
+        <DropdownMenu.Trigger>
+          <IconButton size="2" variant="ghost">
+            {getThemeIcon()}
+          </IconButton>
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Content>
+          <DropdownMenu.Item onClick={() => setTheme("light")}>
+            <Flex align="center" gap="2">
+              <SunIcon />
+              <Text>Light</Text>
+            </Flex>
+          </DropdownMenu.Item>
+          <DropdownMenu.Item onClick={() => setTheme("dark")}>
+            <Flex align="center" gap="2">
+              <MoonIcon />
+              <Text>Dark</Text>
+            </Flex>
+          </DropdownMenu.Item>
+          <DropdownMenu.Item onClick={() => setTheme("system")}>
+            <Flex align="center" gap="2">
+              <LaptopIcon />
+              <Text>System</Text>
+            </Flex>
+          </DropdownMenu.Item>
+        </DropdownMenu.Content>
+      </DropdownMenu.Root>
+    </Flex>
+  );
+}

--- a/src/contexts/ThemeContext.test.tsx
+++ b/src/contexts/ThemeContext.test.tsx
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+import { ThemeProvider, useTheme } from './ThemeContext';
+
+// Mock localStorage
+const mockLocalStorage = {
+  getItem: vi.fn(),
+  setItem: vi.fn(),
+  removeItem: vi.fn(),
+  clear: vi.fn(),
+};
+Object.defineProperty(window, 'localStorage', {
+  value: mockLocalStorage,
+  writable: true,
+});
+
+// Mock matchMedia
+const mockMatchMedia = vi.fn().mockImplementation(query => ({
+  matches: true, // Default to dark mode
+  media: query,
+  onchange: null,
+  addEventListener: vi.fn(),
+  removeEventListener: vi.fn(),
+  dispatchEvent: vi.fn(),
+}));
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: mockMatchMedia,
+});
+
+describe('ThemeContext', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('provides default theme values', () => {
+    const { result } = renderHook(() => useTheme(), {
+      wrapper: ThemeProvider,
+    });
+
+    expect(result.current.theme).toBe('system');
+    expect(result.current.resolvedTheme).toBe('dark');
+  });
+
+  it('loads saved theme from localStorage', () => {
+    mockLocalStorage.getItem.mockReturnValueOnce('light');
+    
+    const { result } = renderHook(() => useTheme(), {
+      wrapper: ThemeProvider,
+    });
+
+    expect(result.current.theme).toBe('light');
+    expect(result.current.resolvedTheme).toBe('light');
+  });
+
+  it('saves theme to localStorage when changed', () => {
+    const { result } = renderHook(() => useTheme(), {
+      wrapper: ThemeProvider,
+    });
+
+    act(() => {
+      result.current.setTheme('dark');
+    });
+
+    expect(mockLocalStorage.setItem).toHaveBeenCalledWith('theme', 'dark');
+    expect(result.current.theme).toBe('dark');
+    expect(result.current.resolvedTheme).toBe('dark');
+  });
+
+  it('resolves system theme based on media query', () => {
+    mockLocalStorage.getItem.mockReturnValue(null); // No saved theme
+    mockMatchMedia.mockImplementation(query => ({
+      matches: true, // dark mode preferred
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+
+    const { result } = renderHook(() => useTheme(), {
+      wrapper: ThemeProvider,
+    });
+
+    expect(result.current.theme).toBe('system');
+    expect(result.current.resolvedTheme).toBe('dark');
+  });
+
+  it('throws error when used outside ThemeProvider', () => {
+    // Suppress console.error for this test
+    const originalError = console.error;
+    console.error = vi.fn();
+
+    expect(() => {
+      renderHook(() => useTheme());
+    }).toThrow('useTheme must be used within a ThemeProvider');
+
+    console.error = originalError;
+  });
+
+  it('updates resolved theme when system preference changes', () => {
+    mockLocalStorage.getItem.mockReturnValue(null); // No saved theme
+    let changeListener: ((event: MediaQueryListEvent) => void) | null = null;
+    
+    mockMatchMedia.mockImplementation(query => ({
+      matches: false, // light mode initially
+      media: query,
+      onchange: null,
+      addEventListener: vi.fn((event, listener) => {
+        if (event === 'change') {
+          changeListener = listener;
+        }
+      }),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+
+    const { result } = renderHook(() => useTheme(), {
+      wrapper: ThemeProvider,
+    });
+
+    expect(result.current.resolvedTheme).toBe('light');
+
+    // Simulate system preference change
+    act(() => {
+      if (changeListener) {
+        changeListener({ matches: true } as MediaQueryListEvent);
+      }
+    });
+
+    expect(result.current.resolvedTheme).toBe('dark');
+  });
+});

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import React, { createContext, useContext, useState, useEffect } from "react";
+
+type ThemeMode = "light" | "dark" | "system";
+
+interface ThemeContextType {
+  theme: ThemeMode;
+  setTheme: (theme: ThemeMode) => void;
+  resolvedTheme: "light" | "dark";
+}
+
+const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setThemeState] = useState<ThemeMode>("system");
+  const [resolvedTheme, setResolvedTheme] = useState<"light" | "dark">("dark");
+
+  useEffect(() => {
+    const savedTheme = localStorage.getItem("theme") as ThemeMode | null;
+    if (savedTheme) {
+      setThemeState(savedTheme);
+    }
+  }, []);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+    
+    const updateResolvedTheme = (e?: MediaQueryListEvent) => {
+      if (theme === "system") {
+        const matches = e ? e.matches : mediaQuery.matches;
+        setResolvedTheme(matches ? "dark" : "light");
+      } else {
+        setResolvedTheme(theme as "light" | "dark");
+      }
+    };
+
+    updateResolvedTheme();
+    
+    if (theme === "system") {
+      mediaQuery.addEventListener("change", updateResolvedTheme);
+      return () => mediaQuery.removeEventListener("change", updateResolvedTheme);
+    }
+  }, [theme]);
+
+  const setTheme = (newTheme: ThemeMode) => {
+    setThemeState(newTheme);
+    localStorage.setItem("theme", newTheme);
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme, resolvedTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error("useTheme must be used within a ThemeProvider");
+  }
+  return context;
+}


### PR DESCRIPTION
## Summary
- Implemented navbar navigation with links to Sessions, Calibration, and Account pages
- Added theme toggle functionality with light/dark/system options
- Created ThemeProvider context for managing theme state across the application

## Test plan
- [x] Navbar displays correctly with all navigation links
- [x] Theme toggle dropdown opens and shows all three options
- [x] Selecting a theme updates the UI and persists to localStorage
- [x] System theme option respects OS preference
- [x] Navigation links highlight when on current page
- [x] All tests pass for Navbar and ThemeContext components

🤖 Generated with [Claude Code](https://claude.ai/code)